### PR TITLE
git documentation: use `git help CMD` instead of `man git-CMD`

### DIFF
--- a/IPS-DEV/index.html
+++ b/IPS-DEV/index.html
@@ -371,7 +371,7 @@ $ git clone http://some.domain.com/path/to/repo.git
 ## Get documentation
 ```shell
 $ # Example: documentation for command 'git clone'
-$ man git-clone
+$ git help clone
 ```
 
 ---


### PR DESCRIPTION
git maintains a one-command-with-subcommands `git CMD` model. For most
purposes, the fact that subcommands are implemented as separate
`git-CMD` commands is an implementation detail. Showing `man git-CMD`
makes students pay attention to this detail, which can confuse or
distract them. Documentation commands like `git help CMD` or `git
CMD --help` are less distracting.

Although I personally use `git CMD --help` out of personal habit,
I think that if we are only going to show one to the student, `git
help CMD` is nicer as they may guess or find out that `git help` also
works and give them valuable information.